### PR TITLE
Fix: #52 remove deprecated frame templates

### DIFF
--- a/Frames/Controller.lua
+++ b/Frames/Controller.lua
@@ -54,7 +54,7 @@ function addon:create_controller_frame()
     controller_frame:SetClampedToScreen(true)
 
     -- Border frame to be toggled with selected texture from Editmode
-    controller_frame.edit_frame = CreateFrame("Frame", nil, controller_frame, "GlowBorderTemplate")
+    controller_frame.edit_frame = CreateFrame("Frame", nil, controller_frame)
     controller_frame.edit_frame:SetSize(controller_frame:GetWidth(), controller_frame:GetHeight())
     controller_frame.edit_frame:SetPoint("CENTER", controller_frame, "CENTER")
     controller_frame.edit_frame:Hide()

--- a/Frames/Keyboard.lua
+++ b/Frames/Keyboard.lua
@@ -55,7 +55,7 @@ function addon:create_keyboard_frame()
     keyboard_frame:SetClampedToScreen(true)
 
     -- Border frame to be toggled with selected texture from Editmode
-    keyboard_frame.edit_frame = CreateFrame("Frame", nil, keyboard_frame, "GlowBorderTemplate")
+    keyboard_frame.edit_frame = CreateFrame("Frame", nil, keyboard_frame)
     keyboard_frame.edit_frame:SetSize(keyboard_frame:GetWidth(), keyboard_frame:GetHeight())
     keyboard_frame.edit_frame:SetPoint("CENTER", keyboard_frame, "CENTER")
     keyboard_frame.edit_frame:Hide()

--- a/Frames/Mouse.lua
+++ b/Frames/Mouse.lua
@@ -58,7 +58,7 @@ function addon:create_mouse_image()
     end)
 
     -- Border frame to be toggled with selected texture from Editmode
-    mouse_image.edit_frame = CreateFrame("Frame", nil, mouse_image, "GlowBorderTemplate")
+    mouse_image.edit_frame = CreateFrame("Frame", nil, mouse_image)
     mouse_image.edit_frame:SetSize(500, mouse_image:GetHeight())
     mouse_image.edit_frame:SetPoint("RIGHT", mouse_image, "RIGHT")
     mouse_image.edit_frame:Hide()

--- a/Frames/Selection.lua
+++ b/Frames/Selection.lua
@@ -241,7 +241,7 @@ function addon:create_selection_frame()
         texture:SetAllPoints(frame)
 
         -- Border frame to be toggled with selected texture from Editmode
-        local border_frame = CreateFrame("Frame", nil, frame, "GlowBorderTemplate")
+        local border_frame = CreateFrame("Frame", nil, frame)
         border_frame:SetSize(frame_width, frame_height)
         border_frame:SetPoint("CENTER", frame, "CENTER")
 


### PR DESCRIPTION
This is a rather simple fix for issue #52 that remove usage of deprecated blizzard frame templates